### PR TITLE
Add "GitHub Pages" workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,19 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.70.0'
+      - run: hugo --minify
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
master ブランチの変更をトリガに GitHub Pages を更新するワークフローを追加します。一度も実行されていないのでうまく動作するか不明ですが、動かなかったときは修正します。