### PR TITLE
Add a registration URL to Kubernetes upstream trainning

### DIFF
--- a/content/sessions/4.md
+++ b/content/sessions/4.md
@@ -9,3 +9,9 @@ lang: japanese
 KubernetesアップストリームトレーニングはKubernetesの新機能開発・バグ修正・ドキュメント作成などのコミュニティ開発を円滑に行うためのトレーニングプログラムです。参加者はKubernetesコミュニティの概要を把握できることに加えて、Kubernetesコミュニティに対する具体的な貢献方法をハンズオン形式で学ぶことが出来ます。
 
 講師は Kubernetes コミュニティにおいてMember以上の開発者で構成されており、日本語での議論・相談が可能です。技術面だけでなく、オープンなコミュニティにおけるコミュニケーションや議論の進め方など、提案を受け入れてもらうための手法についてもお伝えします。
+
+### 参加申込み方法
+
+Kubernetesアップストリームトレーニングに参加を希望される方は、下記フォームから6/4 (木) までに申込みください。
+
+- [KubeFest Tokyo 2020 \- Kubernetes アップストリームトレーニング参加申込](https://docs.google.com/forms/d/e/1FAIpQLSelPLMcImVFJsyI7woY1sjFxH4qL5gAK5ZNuqv2RkLvTAjySw/viewform)


### PR DESCRIPTION
Kubernetes アップストリームトレーニングの申込みフォームの URL をセッション概要に追記します。