### PR TITLE
Fix sponsor session time to 30m

### DIFF
--- a/themes/kubefest/layouts/sessions/single.html
+++ b/themes/kubefest/layouts/sessions/single.html
@@ -8,7 +8,7 @@
   <div class="session-tags">
     <span class="tag tag-lang">{{.Params.lang|title}}</span>
     <span class="tag tag-format">{{.Params.format|title}} Session</span></span>
-    <span class="tag tag-time">{{ if eq .Params.format "lt" }}5m{{else if eq .Params.format "training"}}{{else}}35m{{end}}</span>
+    <span class="tag tag-time">{{ if eq .Params.format "lt" }}5m{{else if eq .Params.format "training"}}{{else if eq .Params.format "sponsor"}}30m{{else}}35m{{end}}</span>
   </div>
 
   <h2>概要</h2>


### PR DESCRIPTION
スポンサセッションの持ち時間が30分のところ"35m"と記載されているため修正します。