### PR TITLE
Add start date time to single session pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.70.0'
-      - run: hugo --minify
+      - run: hugo --minify -F
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+serve:
+		hugo serve -F

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Check website on local machine
 
 ```bash
-$ hugo server
+$ hugo server -F
 ```
 
 ## How to add conference info?

--- a/content/sessions/1.md
+++ b/content/sessions/1.md
@@ -1,6 +1,7 @@
 ---
 id: 1
 title: "ヤフー/ゼットラボのステートフルアプリケーションへの挑戦"
+date: 2020-06-13T10:30:00+09:00
 format: "dual"
 speakers: [1, 2]
 lang: japanese

--- a/content/sessions/10.md
+++ b/content/sessions/10.md
@@ -1,6 +1,7 @@
 ---
 id: 10
 title: "負荷を予測して事前スケーリングする HPA の Custom Controller 実装"
+date: 2020-06-13T13:40:00+09:00
 format: "solo"
 speakers: [14]
 lang: japanese

--- a/content/sessions/11.md
+++ b/content/sessions/11.md
@@ -1,6 +1,7 @@
 ---
 id: 11
 title: "The potential of Kubernetes as more than just an infrastructure to deploy"
+date: 2020-06-13T15:35:00+09:00
 format: "solo"
 speakers: [15]
 lang: japanese

--- a/content/sessions/12.md
+++ b/content/sessions/12.md
@@ -1,6 +1,7 @@
 ---
 id: 12
 title: "Understanding CPU throttling in Kubernetes to improve application performance"
+date: 2020-06-13T16:25:00+09:00
 format: "solo"
 speakers: [16]
 lang: japanese

--- a/content/sessions/13.md
+++ b/content/sessions/13.md
@@ -1,6 +1,7 @@
 ---
 id: 13
 title: "Kubernetes based connected vehicle platform"
+date: 2020-06-13T16:25:00+09:00
 format: "solo"
 speakers: [17, 18]
 lang: english

--- a/content/sessions/14.md
+++ b/content/sessions/14.md
@@ -1,6 +1,7 @@
 ---
 id: 14
 title: "Resilience Engineering on Kubernetes ～ワンターレンの夜明け～"
+date: 2020-06-13T12:10:00+09:00
 format: "sponsor"
 speakers: [19]
 lang: japanese

--- a/content/sessions/15.md
+++ b/content/sessions/15.md
@@ -1,6 +1,7 @@
 ---
 id: 15
 title: "VMとAWS ECSがメインのインフラにKubernetesを導入した効能"
+date: 2020-06-13T12:10:00+09:00
 format: "sponsor"
 speakers: [20]
 lang: japanese

--- a/content/sessions/16.md
+++ b/content/sessions/16.md
@@ -1,6 +1,7 @@
 ---
 id: 16
 title: "Preparing the guardrails for Istio at scale"
+date: 2020-06-13T12:55:00+09:00
 format: "sponsor"
 speakers: [21]
 lang: english

--- a/content/sessions/17.md
+++ b/content/sessions/17.md
@@ -1,6 +1,7 @@
 ---
 id: 17
 title: "Kubernetes とオープンソース"
+date: 2020-06-13T12:55:00+09:00
 format: "sponsor"
 speakers: [22]
 lang: japanese

--- a/content/sessions/2.md
+++ b/content/sessions/2.md
@@ -1,6 +1,7 @@
 ---
 id: 2
 title: "分散密ベクトル探索エンジン Vald の Helm Chart の作成と Operator SDK を用いた Helm ベースの Operator の開発"
+date: 2020-06-13T13:40:00+09:00
 format: "solo"
 speakers: [3]
 lang: japanese

--- a/content/sessions/3.md
+++ b/content/sessions/3.md
@@ -1,6 +1,7 @@
 ---
 id: 3
 title: "Container Storage Interface のすべて"
+date: 2020-06-13T11:20:00+09:00
 format: "solo"
 speakers: [4]
 lang: japanese

--- a/content/sessions/4.md
+++ b/content/sessions/4.md
@@ -1,6 +1,7 @@
 ---
 id: 4
 title: "Kubernetesアップストリームトレーニング"
+date: 2020-06-13T13:40:00+09:00
 format: "training"
 speakers: [5, 6]
 lang: japanese

--- a/content/sessions/5.md
+++ b/content/sessions/5.md
@@ -1,6 +1,7 @@
 ---
 id: 5
 title: "Open Policy AgentとSpinnakerで実現するマイクロサービスの安全な継続的デリバリー"
+date: 2020-06-13T15:35:00+09:00
 format: "solo"
 speakers: [7]
 lang: japanese

--- a/content/sessions/6.md
+++ b/content/sessions/6.md
@@ -1,6 +1,7 @@
 ---
 id: 6
 title: "Kubernetesトラブル原因特定容易化に向けたロギング強化機能"
+date: 2020-06-13T11:20:00+09:00
 format: "dual"
 speakers: [8, 9]
 lang: japanese

--- a/content/sessions/7.md
+++ b/content/sessions/7.md
@@ -1,6 +1,7 @@
 ---
 id: 7
 title: "Open Policy Agent を使ってベスト・プラクティスをコード化しよう"
+date: 2020-06-13T10:30:00+09:00
 format: "solo"
 speakers: [10]
 lang: japanese

--- a/content/sessions/8.md
+++ b/content/sessions/8.md
@@ -1,6 +1,7 @@
 ---
 id: 8
 title: "Kubernetesクラスタのマルチテナンシーベストプラクティス"
+date: 2020-06-13T14:30:00+09:00
 format: "solo"
 speakers: [11]
 lang: japanese

--- a/content/sessions/9.md
+++ b/content/sessions/9.md
@@ -1,6 +1,7 @@
 ---
 id: 9
 title: "運用性向上のためのベアメタルサーバ制御機能の紹介"
+date: 2020-06-13T14:30:00+09:00
 format: "dual"
 speakers: [12, 13]
 lang: japanese

--- a/themes/kubefest/layouts/sessions/single.html
+++ b/themes/kubefest/layouts/sessions/single.html
@@ -8,6 +8,9 @@
   <div class="session-tags">
     <span class="tag tag-lang">{{.Params.lang|title}}</span>
     <span class="tag tag-format">{{.Params.format|title}} Session</span></span>
+    {{ if .Date }}
+    <span class="tag tag-date">{{ .Date.Local.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</span>
+    {{ end }}
     <span class="tag tag-time">{{ if eq .Params.format "lt" }}5m{{else if eq .Params.format "training"}}{{else if eq .Params.format "sponsor"}}30m{{else}}35m{{end}}</span>
   </div>
 


### PR DESCRIPTION
通常セッションのシングルページに開始日時を追加します。LT の個々の時間はいらないと思うので設定していません。

Hugo はデフォルトだと未来のエントリを表示しないため、未来のエントリも表示するように `-F` オプションをビルド時に追加します。

![image](https://user-images.githubusercontent.com/230185/84280708-9ef99680-ab72-11ea-9836-4dfb4b75e6ce.png)
