### PR TITLE
Specify Timezone to Asia/Tokyo on CI

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.70.0'
-      - run: hugo --minify -F
+      - run: TZ="Asia/Tokyo" hugo --minify -F
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
マークダウンの変換時にタイムゾーンを指定してなかったことで、GMT で日時が表示されてしまっていました。